### PR TITLE
fix(@zakelstorm/blog): Sidebar Toggle 버튼 클릭 시 Sidebar 안열리던 현상 수정

### DIFF
--- a/apps/blog/features/Sidebars/SidebarWrapper.tsx
+++ b/apps/blog/features/Sidebars/SidebarWrapper.tsx
@@ -30,12 +30,12 @@ export const SidebarWrapper = ({
     }
 
     if (isOpen && breakPoint === 'desktop') {
-      aside.style.display = 'block'
       animate([
         ['path.top', { d: 'M 3 16.5 L 17 2.5' }],
         ['path.middle', { opacity: 0 }, { at: '<' }],
         ['path.bottom', { d: 'M 3 2.5 L 17 16.346' }, { at: '<' }],
         ['aside', { width: '250px' }, { at: '<' }],
+        ['aside', { padding: '20px' }, { at: '<' }],
         ['aside *', { opacity: 1 }],
       ])
     } else {
@@ -45,9 +45,8 @@ export const SidebarWrapper = ({
         ['path.bottom', { d: 'M 2 16.346 L 20 16.346' }, { at: '<' }],
         ['aside *', { opacity: 0 }, { at: '<', duration: 0 }],
         ['aside', { width: 0 }, { at: '<' }],
-      ]).then(() => {
-        aside.style.display = 'none'
-      })
+        ['aside', { padding: 0 }, { at: '<' }],
+      ])
     }
   }, [animate, breakPoint, isOpen, scope])
 
@@ -57,7 +56,7 @@ export const SidebarWrapper = ({
         id='sidebar'
         aria-hidden={!isOpen}
         className={twMerge(
-          `fixed right-0 bottom-0 top-0 bg-neutral-800 p-20 w-0 text-gray-300 [&>*]:opacity-0 hidden`,
+          `fixed right-0 bottom-0 top-0 bg-neutral-800 w-0 text-gray-300 [&>*]:opacity-0`,
           className
         )}>
         {children}


### PR DESCRIPTION
### 🏎 접근성 체크리스트


| 검사항목 | 검사여부 |
|----------|-----|
| 이미지에 대체텍스트가 제공되었는가 |<ul><li>[ ] </li></ul>|
| 차트에 테이블 마크업으로 대체 텍스트가 제공되었는가 |<ul><li>[ ] </li></ul>|
| 대체텍스트가 이미지를 상세하게 설명하고 있는가 |<ul><li>[ ] </li></ul>|
| 캡챠 이미지의 alt에 보안문자가 제공되지 않았는가 |<ul><li>[ ] </li></ul>|
| 사용자가 이미지를 업로드하는 경우 대체텍스트를 제공하는 입력이 제공되었는가 |<ul><li>[ ] </li></ul>|
| 동영상에 자막이 제공되었는가 |<ul><li>[ ] </li></ul>|
| 동영상에 텍스트만 나오는 경우 스크립트가 제공되었는가 |<ul><li>[ ] </li></ul>|
| 사용자가 동영상을 업로드하는 경우 스크립트 혹은 자막을 제공하는 입력이 제공되었는가 |<ul><li>[ ] </li></ul>|
| Pagiation, Carousel, 탭, 차트가 콘텐츠가 색에 무관하게 인식될 수 있는가 ex) 패턴, 굵기 |<ul><li>[ ] </li></ul>|
| 지시사항이 모양, 크기, 위치, 방향, 색, 소리 등에 관계없이 인식될 수 있는가 |<ul><li>[ ] </li></ul>|
| 아이콘/기호를 이용하여 지시사항을 전달할 경우 아이콘/기호에혹은 부가적인 설명이 제공되는가 |<ul><li>[ ] </li></ul>|
| 색을 이용한 설명이 제공되지 않았는가 |<ul><li>[ ] </li></ul>|
| 텍스트와 배경간의 명도대비가 3대1 이상인가 |<ul><li>[ ] </li></ul>|
| 페이지 진입/ 마우스 호버 시 자동으로 동영상/소리가 재생되지 않는가 |<ul><li>[ ] </li></ul>|
| 모든 기능을 키보드로 사용이 가능한가 |<ul><li>[ ] </li></ul>|
| 이웃한 컨텐츠를 border(혹은 채도대비 혹은 패턴 혹은 줄/글자 간격 혹은 기타 방법)으로 구분할 수 있는가 |<ul><li>[ ] </li></ul>|
| Focus의 위치를 시각적으로 알 수 있는가 |<ul><li>[ ] </li></ul>|
| 1이상의 tabindex가 강제로 지정되지 않았는가 |<ul><li>[ ] </li></ul>|
| Form 내에서 submit에 Focus 순서가 가장 뒤늦게 배치되었는가 |<ul><li>[ ] </li></ul>|
| 팝업이 열리는 경우 열렸을때 초점이 팝업 내부로 이동하고 닫혔을때 팝업을 열었던 컨트롤로 Focus가 이동하는가 |<ul><li>[ ] </li></ul>|
| 버튼의 크기가 대각선으로 6mm이상인가 |<ul><li>[ ] </li></ul>|
| 컨트롤이 연달아 있는 경우 1px이상의 gap이 제공되었는가 |<ul><li>[ ] </li></ul>|
| 시간제한이 있는 콘텐츠를 가급적으로 넣지 않았는가 |<ul><li>[ ] </li></ul>|
| 시간제한이 있는 콘텐츠의 응답시간을 조절할 수 있는가 |<ul><li>[ ] </li></ul>|
| 자동으로 변경되는 컨텐츠의 움직임을 제어할 수 있는가 ex) Carousel, 실시간 급상승 |<ul><li>[ ] </li></ul>|
| 초당 3~50회 주기로 깜빡이는 컨텐츠를 제공하지 않았는가 |<ul><li>[ ] </li></ul>|
| 모든 페이지에 공통적으로 들어있는 부분을 건너뛸 수 있는 버튼이 페이지 가장 앞에 제공 되었는가 ex) 본문으로 이동하기, 주메뉴로 이동하기 |<ul><li>[ ] </li></ul>|
| 모든 페이지에 공통적으로 들어있는 부분이 키보드 접근시 화면에 노출되는가 |<ul><li>[ ] </li></ul>|
| 웹페이지 제목이 유일한가 |<ul><li>[ ] </li></ul>|
| 웹페이지 제목에 특수기호가 2개이상 제공되지 않았는가 |<ul><li>[ ] </li></ul>|
| iframe에도 title이 지정되었는가 ex)&lt;iframe title=&quot;광고&quot; /&gt; |<ul><li>[ ] </li></ul>|
| 섬네일과 텍스트를 클릭했을때 동일한 링크로 이동할때 이 둘을 하나로 묶어서 링크가 제공되었는가 |<ul><li>[ ] </li></ul>|
| html 태그에 lang으로 주로 사용하는 언어가 지정되었는가 |<ul><li>[ ] </li></ul>|
| 페이지 진입 시 새창이 뜨는 경우가 없는가 |<ul><li>[ ] </li></ul>|
| 컨트롤을 클릭했을 때 새창이 뜬다는 것을 미리 알려주는가 |<ul><li>[ ] </li></ul>|
| 컨텐츠가 논리적인 순서로 제공되었는가 ex) 탭 1제목 &gt; &quot;탭 1내용 &gt; 탭2제목 &gt; 탭2 내용&quot; 혹은 &quot;내용 상단에 invisible 제목 제공&quot; |<ul><li>[ ] </li></ul>|
| 테이블 th에 scope가 설정되었는가 |<ul><li>[ ] </li></ul>|
| 테이블 제목/요약(caption)이 제공되었는가 |<ul><li>[ ] </li></ul>|
| 복잡한 테이블의 경우 th의 id와 td의 headers가 연결되었는가 |<ul><li>[ ] </li></ul>|
| input에 대응하는 label이 제공되었는가 |<ul><li>[ ] </li></ul>|
| 한개의 label이 여러개의 input과 매칭되어야하는 경우 input 마다 title혹은 arial-label이 제공되었는가 ex) &quot;생년월일 중 년 4자리 입력&quot;, &quot;생년월일 중 월 입력&quot; |<ul><li>[ ] </li></ul>|
| label이 없어야하는 경우 input에 title혹은 aria-label이 제공되었는가 |<ul><li>[ ] </li></ul>|
| 입력서식에 오류가 있는경우 오류가 발생한 입력 서식으로 Focus가 이동되는가 |<ul><li>[ ] </li></ul>|
| 입력서식에 오류가 있는경우 원인 혹은 해결방법을 알려주었는가 |<ul><li>[ ] </li></ul>|
